### PR TITLE
readme: fix code block display

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ fn main() {
 
 The above example can be run like so:
 
-```ignore
+```text
 $ git clone git://github.com/BurntSushi/rust-csv
 $ cd rust-csv
 $ cargo run --example cookbook-read-basic < examples/data/smallpop.csv
@@ -110,7 +110,7 @@ fn main() {
 
 The above example can be run like so:
 
-```ignore
+```text
 $ git clone git://github.com/BurntSushi/rust-csv
 $ cd rust-csv
 $ cargo run --example cookbook-read-serde < examples/data/smallpop.csv


### PR DESCRIPTION
By default, code blocks are considered as rust one by rustdoc.
To prevent this, we just use `text`.

PR #185