### PR TITLE
api: suppress Error::description deprecation

### DIFF
--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -738,6 +738,7 @@ impl DeserializeError {
 }
 
 impl DeserializeErrorKind {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         use self::DeserializeErrorKind::*;
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -358,12 +358,7 @@ fn example_bin_dir() -> PathBuf {
 
 /// Return the repo root directory path.
 fn repo_dir() -> PathBuf {
-    debug_dir()
-        .parent()
-        .expect("target directory")
-        .parent()
-        .expect("repo directory")
-        .to_path_buf()
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
 /// Return the directory containing the example data.


### PR DESCRIPTION
Removing it outright is technically a breaking change, so we just leave
it in for now until csv 2.

And also use CARGO_MANMIFEST_DIR instead of directory traversal
hacks in tests.